### PR TITLE
Change closeTag() to private and add new method close()

### DIFF
--- a/src/ru/mw/util/xml/XMLBuilder.java
+++ b/src/ru/mw/util/xml/XMLBuilder.java
@@ -178,7 +178,7 @@ public class XMLBuilder {
         return closeTag(lastTag);
     }
 	
-	public XMLBuilder close() {
+    public XMLBuilder close() {
         while(tags.size() > 0){
             up();
         }


### PR DESCRIPTION
1) changed **closeTag()** to private
**closeTag()** closed XML with incorrect formatting. Preferably use **up()** or new method **close()** for correct closing tags. It's not a bug, but generated XML look not so pretty.
2) added new method **close()**
He can be used to quick add close tags in very big XML.
